### PR TITLE
SECURITY/BUGFIX: add check for empty username and/or password

### DIFF
--- a/ldap-client.go
+++ b/ldap-client.go
@@ -113,9 +113,13 @@ func (lc *LDAPClient) Authenticate(username, password string) (bool, map[string]
 	}
 
 	// Bind as the user to verify their password
-	err = lc.Conn.Bind(userDN, password)
-	if err != nil {
-		return false, user, err
+	if userDN != "" && password != "" {
+		err = lc.Conn.Bind(userDN, password)
+		if err != nil {
+			return false, user, err
+		}
+	} else {
+		return false, user, errors.New("No username/passowrd provided.")
 	}
 
 	// Rebind as the read only user for any further queries


### PR DESCRIPTION
- See https://github.com/jtblin/go-ldap-client/issues/16
- This is a major bug that would return true on Authenticate with an empty password!